### PR TITLE
feature: add group chat history logging for channel agents

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -262,7 +262,13 @@ func (r *AgentRunner) promptCore(ctx context.Context, message, mediaURL string, 
 			useHistory = *overrides.History
 		}
 		if useHistory {
-			if history := r.loadSessionConversation(sessionID, 24); len(history) > 0 {
+			// For channel sessions, prefer the chat log over the session JSONL: the
+			// chat log captures ALL group messages (not just agent-triggering ones),
+			// so non-triggering user messages become real conversation turns instead
+			// of hidden system-prompt context.
+			if chHistory := r.loadChannelConversation(promptCtx); len(chHistory) > 0 {
+				conversation = chHistory
+			} else if history := r.loadSessionConversation(sessionID, 24); len(history) > 0 {
 				conversation = history
 			}
 		}
@@ -482,6 +488,7 @@ func (r *AgentRunner) promptCore(ctx context.Context, message, mediaURL string, 
 				if answer != "" {
 					r.appendSessionMessage(sessionID, domain.MessageRoleAssistant, answer, "", effectiveModel)
 					r.appendMemoryMessage(sessionID, domain.MessageRoleAssistant, answer)
+					r.appendChatLogEntry(promptCtx, "assistant", r.agent.Name, answer)
 					r.maybeCompactMemory()
 				}
 				slog.Info("agent: prompt done", "agent", r.agent.Name, "model", effectiveModel)
@@ -604,6 +611,29 @@ func (r *AgentRunner) appendSessionMessage(sessionID string, role domain.Message
 		return
 	}
 	notifySessionMessage(sessionID, string(role))
+}
+
+// appendChatLogEntry writes a message to the group chat log when the context
+// carries a channel session. This keeps the chat transcript up to date with
+// both user messages (written by the channel manager) and agent replies.
+func (r *AgentRunner) appendChatLogEntry(ctx context.Context, role, from, text string) {
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	chType, _, chID, ok := ChannelSessionFromContext(ctx)
+	if !ok || chType == "" || chID == "" {
+		return
+	}
+	path := store.ChatLogPath(r.agent.ID, chType, chID)
+	entry := store.ChatLogEntry{
+		From:      from,
+		Role:      role,
+		Text:      text,
+		Timestamp: time.Now(),
+	}
+	if err := store.AppendChatLog(path, entry, 0); err != nil {
+		slog.Warn("agent: failed to append chat log", "agent", r.agent.Name, "err", err)
+	}
 }
 
 func (r *AgentRunner) appendMemoryMessage(sessionID string, role domain.MessageRole, content string) {
@@ -1669,3 +1699,50 @@ func (r *AgentRunner) Agent() *domain.Agent { return r.agent }
 
 // Config returns the agent's config snapshot.
 func (r *AgentRunner) Config() *config.AgentConfig { return r.cfg }
+
+// loadChannelConversation builds a conversation message slice from the group
+// chat log for the channel session carried in ctx. Unlike loadSessionConversation
+// (which only contains agent-triggered turns), the chat log records every
+// group message, so non-triggering user messages appear as real conversation
+// turns. Consecutive user messages are merged to satisfy LLM alternation rules.
+// Returns nil if there is no channel session or the chat log is empty.
+func (r *AgentRunner) loadChannelConversation(ctx context.Context) []llm.Message {
+	chType, _, chID, ok := ChannelSessionFromContext(ctx)
+	if !ok || chType == "" || chID == "" {
+		return nil
+	}
+	entries, err := store.ReadChatLog(store.ChatLogPath(r.agent.ID, chType, chID))
+	if err != nil || len(entries) == 0 {
+		return nil
+	}
+
+	var msgs []llm.Message
+	for _, e := range entries {
+		text := strings.TrimSpace(e.Text)
+		if text == "" {
+			continue
+		}
+		var role llm.Role
+		var content string
+		switch e.Role {
+		case "assistant":
+			role = llm.RoleAssistant
+			content = text
+		default:
+			role = llm.RoleUser
+			from := strings.TrimSpace(e.From)
+			if from != "" {
+				content = from + ": " + text
+			} else {
+				content = text
+			}
+		}
+		// Merge consecutive messages of the same role to satisfy alternation rules.
+		if len(msgs) > 0 && msgs[len(msgs)-1].Role == role {
+			msgs[len(msgs)-1].Content += "\n" + content
+		} else {
+			msgs = append(msgs, llm.Message{Role: role, Content: content})
+		}
+	}
+	return msgs
+}

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -70,3 +70,11 @@ type TypingSender interface {
 type MediaSender interface {
 	SendMedia(channel, caption, filePath string) error
 }
+
+// GroupChatLogger is an optional interface for channels that can log all
+// incoming group messages before allowFrom filtering. The registered callback
+// is invoked for every group message regardless of permission rules, allowing
+// the caller to build a full channel transcript for context.
+type GroupChatLogger interface {
+	OnGroupChatMessage(fn func(IncomingMessage))
+}

--- a/internal/channels/discord.go
+++ b/internal/channels/discord.go
@@ -21,11 +21,12 @@ type DiscordChannel struct {
 	fallbacks     []string
 	disabledTools []string
 
-	session   *discordgo.Session
-	handler   func(IncomingMessage)
-	handlerMu sync.RWMutex
-	stopOnce  sync.Once
-	done      chan struct{}
+	session         *discordgo.Session
+	handler         func(IncomingMessage)
+	groupLogHandler func(IncomingMessage)
+	handlerMu       sync.RWMutex
+	stopOnce        sync.Once
+	done            chan struct{}
 }
 
 // NewDiscordChannel creates a DiscordChannel with the given bot token.
@@ -44,6 +45,14 @@ func (c *DiscordChannel) OnMessage(fn func(IncomingMessage)) {
 	c.handlerMu.Lock()
 	defer c.handlerMu.Unlock()
 	c.handler = fn
+}
+
+// OnGroupChatMessage registers a callback invoked for all group messages before
+// allowFrom filtering, enabling a full channel transcript to be maintained.
+func (c *DiscordChannel) OnGroupChatMessage(fn func(IncomingMessage)) {
+	c.handlerMu.Lock()
+	defer c.handlerMu.Unlock()
+	c.groupLogHandler = fn
 }
 
 // Send posts a message to a Discord channel by ID.
@@ -124,6 +133,29 @@ func (c *DiscordChannel) handleMessage(msg *discordgo.Message, botUserID string)
 
 	// Messages sent in a guild channel have a non-empty GuildID.
 	isGroup := msg.GuildID != ""
+
+	receivedAt := time.Now().UTC()
+	if !msg.Timestamp.IsZero() {
+		receivedAt = msg.Timestamp.UTC()
+	}
+	mediaURL := firstDiscordImageDataURL(msg.Attachments)
+
+	// Log all group messages before allowFrom filtering.
+	if isGroup {
+		c.handlerMu.RLock()
+		logFn := c.groupLogHandler
+		c.handlerMu.RUnlock()
+		if logFn != nil {
+			logFn(IncomingMessage{
+				Type:       "discord",
+				From:       msg.Author.ID,
+				Channel:    msg.ChannelID,
+				Text:       msg.Content,
+				ReceivedAt: receivedAt,
+			})
+		}
+	}
+
 	result := checkAllowed(c.allowFrom, msg.Author.ID, msg.ChannelID, msg.Content, isGroup, botUserID, false)
 	if !result.allowed {
 		return false
@@ -133,11 +165,6 @@ func (c *DiscordChannel) handleMessage(msg *discordgo.Message, botUserID string)
 	fn := c.handler
 	c.handlerMu.RUnlock()
 	if fn != nil {
-		receivedAt := time.Now().UTC()
-		if !msg.Timestamp.IsZero() {
-			receivedAt = msg.Timestamp.UTC()
-		}
-		mediaURL := firstDiscordImageDataURL(msg.Attachments)
 		im := IncomingMessage{
 			Type:          "discord",
 			From:          msg.Author.ID,

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -186,6 +186,26 @@ func (m *Manager) startChannelLocked(ctx context.Context, key string, spec chann
 
 	agentName := spec.agentName
 	channelMeta := spec.metadata
+
+	// Register the group chat logger if the channel supports it.
+	if gcl, ok := ch.(GroupChatLogger); ok {
+		if history := spec.channelConfig.EffectiveGroupChatHistory(); history > 0 {
+			agentID := "agent_" + agentName
+			gcl.OnGroupChatMessage(func(msg IncomingMessage) {
+				path := store.ChatLogPath(agentID, msg.Type, msg.Channel)
+				entry := store.ChatLogEntry{
+					From:      msg.From,
+					Role:      "user",
+					Text:      msg.Text,
+					Timestamp: msg.ReceivedAt,
+				}
+				if err := store.AppendChatLog(path, entry, history); err != nil {
+					slog.Warn("channel: failed to log group chat message", "err", err)
+				}
+			})
+		}
+	}
+
 	ch.OnMessage(func(msg IncomingMessage) {
 		if !shouldProcessIncomingMessage(channelMeta, msg) {
 			return

--- a/internal/channels/signal.go
+++ b/internal/channels/signal.go
@@ -255,11 +255,12 @@ type SignalChannel struct {
 	addrMu sync.RWMutex
 	addr   string
 
-	handler   func(IncomingMessage)
-	handlerMu sync.RWMutex
-	stopOnce  sync.Once
-	done      chan struct{}
-	idSeq     atomic.Int64
+	handler         func(IncomingMessage)
+	groupLogHandler func(IncomingMessage)
+	handlerMu       sync.RWMutex
+	stopOnce        sync.Once
+	done            chan struct{}
+	idSeq           atomic.Int64
 
 	logSinkMu sync.RWMutex
 	logSink   *LogSink
@@ -334,6 +335,14 @@ func (c *SignalChannel) OnMessage(fn func(IncomingMessage)) {
 	c.handlerMu.Lock()
 	defer c.handlerMu.Unlock()
 	c.handler = fn
+}
+
+// OnGroupChatMessage registers a callback invoked for all group messages before
+// allowFrom filtering, enabling a full channel transcript to be maintained.
+func (c *SignalChannel) OnGroupChatMessage(fn func(IncomingMessage)) {
+	c.handlerMu.Lock()
+	defer c.handlerMu.Unlock()
+	c.groupLogHandler = fn
 }
 
 // Send sends a Signal message to a recipient or group via JSON-RPC over TCP.
@@ -977,6 +986,27 @@ func (c *SignalChannel) dispatchEnvelope(source string, msgTimestamp int64, wasM
 		channelID = dataMessage.GroupInfo.GroupID
 	}
 
+	receivedAt := time.Now().UTC()
+	if msgTimestamp > 0 {
+		receivedAt = time.UnixMilli(msgTimestamp).UTC()
+	}
+
+	// Log all group messages before allowFrom filtering.
+	if isGroup {
+		c.handlerMu.RLock()
+		logFn := c.groupLogHandler
+		c.handlerMu.RUnlock()
+		if logFn != nil {
+			logFn(IncomingMessage{
+				Type:       "signal",
+				From:       source,
+				Channel:    channelID,
+				Text:       dataMessage.Message,
+				ReceivedAt: receivedAt,
+			})
+		}
+	}
+
 	// Replies to the agent's own messages must still match an allowFrom entry's
 	// sender and group scope; replyToReplies only relaxes mention gating so the
 	// user can continue the same allowed conversation without re-mentioning.
@@ -993,10 +1023,6 @@ func (c *SignalChannel) dispatchEnvelope(source string, msgTimestamp int64, wasM
 	c.handlerMu.RUnlock()
 
 	if fn != nil {
-		receivedAt := time.Now().UTC()
-		if msgTimestamp > 0 {
-			receivedAt = time.UnixMilli(msgTimestamp).UTC()
-		}
 		im := IncomingMessage{
 			Type:          "signal",
 			From:          source,

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -26,12 +26,13 @@ type SlackChannel struct {
 
 	botUserID string // populated on connect via auth.test
 
-	client    *slack.Client
-	sm        *socketmode.Client
-	handler   func(IncomingMessage)
-	handlerMu sync.RWMutex
-	stopOnce  sync.Once
-	cancel    context.CancelFunc
+	client          *slack.Client
+	sm              *socketmode.Client
+	handler         func(IncomingMessage)
+	groupLogHandler func(IncomingMessage)
+	handlerMu       sync.RWMutex
+	stopOnce        sync.Once
+	cancel          context.CancelFunc
 }
 
 // NewSlackChannel creates a SlackChannel.
@@ -55,6 +56,14 @@ func (c *SlackChannel) OnMessage(fn func(IncomingMessage)) {
 	c.handlerMu.Lock()
 	defer c.handlerMu.Unlock()
 	c.handler = fn
+}
+
+// OnGroupChatMessage registers a callback invoked for all group messages before
+// allowFrom filtering, enabling a full channel transcript to be maintained.
+func (c *SlackChannel) OnGroupChatMessage(fn func(IncomingMessage)) {
+	c.handlerMu.Lock()
+	defer c.handlerMu.Unlock()
+	c.groupLogHandler = fn
 }
 
 // Send posts a message to a Slack channel.
@@ -152,6 +161,32 @@ func (c *SlackChannel) handleMessageEvent(event *slackevents.MessageEvent) {
 
 	// Slack DM channels start with 'D'; everything else is a group/channel.
 	isGroup := !strings.HasPrefix(channelID, "D")
+
+	receivedAt := time.Now().UTC()
+	rawTimestamp := event.TimeStamp
+	if isEdited && event.Message != nil && event.Message.Timestamp != "" {
+		rawTimestamp = event.Message.Timestamp
+	}
+	if ts, ok := parseSlackTimestamp(rawTimestamp); ok {
+		receivedAt = ts
+	}
+
+	// Log all group messages before allowFrom filtering.
+	if isGroup {
+		c.handlerMu.RLock()
+		logFn := c.groupLogHandler
+		c.handlerMu.RUnlock()
+		if logFn != nil {
+			logFn(IncomingMessage{
+				Type:       "slack",
+				From:       from,
+				Channel:    channelID,
+				Text:       text,
+				ReceivedAt: receivedAt,
+			})
+		}
+	}
+
 	result := checkAllowed(c.allowFrom, from, channelID, text, isGroup, c.botUserID, false)
 	if !result.allowed {
 		return
@@ -162,14 +197,6 @@ func (c *SlackChannel) handleMessageEvent(event *slackevents.MessageEvent) {
 	c.handlerMu.RUnlock()
 
 	if fn != nil {
-		receivedAt := time.Now().UTC()
-		rawTimestamp := event.TimeStamp
-		if isEdited && event.Message != nil && event.Message.Timestamp != "" {
-			rawTimestamp = event.Message.Timestamp
-		}
-		if ts, ok := parseSlackTimestamp(rawTimestamp); ok {
-			receivedAt = ts
-		}
 		mediaURL := c.firstImageDataURL(files)
 		im := IncomingMessage{
 			Type:          "slack",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,6 +199,26 @@ type ChannelConfig struct {
 	Model string `yaml:"model,omitempty" json:"model,omitempty"`
 	// Fallbacks overrides the agent's default fallbacks for all messages on this channel.
 	Fallbacks []string `yaml:"fallbacks,omitempty" json:"fallbacks,omitempty"`
+	// GroupChatHistory is the number of recent group chat messages to log and
+	// provide as context to the agent. 0 means use the default (50).
+	// Set to -1 to disable group chat history logging entirely.
+	GroupChatHistory int `yaml:"group_chat_history,omitempty" json:"group_chat_history,omitempty"`
+}
+
+// DefaultGroupChatHistory is the default number of group chat messages retained
+// in the chat log and provided as context to the agent.
+const DefaultGroupChatHistory = 50
+
+// EffectiveGroupChatHistory returns the number of group chat messages to retain.
+// Returns 0 if logging is disabled (GroupChatHistory == -1).
+func (c ChannelConfig) EffectiveGroupChatHistory() int {
+	if c.GroupChatHistory < 0 {
+		return 0 // disabled
+	}
+	if c.GroupChatHistory == 0 {
+		return DefaultGroupChatHistory
+	}
+	return c.GroupChatHistory
 }
 
 // BoolOr returns the value of b if non-nil, otherwise def.

--- a/internal/store/chatlog.go
+++ b/internal/store/chatlog.go
@@ -1,0 +1,55 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ChatLogEntry is a single message in a group channel's chat log.
+type ChatLogEntry struct {
+	From      string    `json:"from"`      // user ID or name who sent the message
+	Role      string    `json:"role"`      // "user" or "assistant"
+	Text      string    `json:"text"`      // message text
+	Timestamp time.Time `json:"timestamp"` // when received
+}
+
+// ChatLogPath returns the path for a channel's chat log file.
+// It lives alongside session files: <datadir>/agents/<agentID>/sessions/<channelType>:<channelID>.chat.jsonl
+func ChatLogPath(agentID, channelType, channelID string) string {
+	name := sanitizeFileComponent(channelType + ":" + channelID)
+	return filepath.Join(AgentDir(agentID), "sessions", name+".chat.jsonl")
+}
+
+// AppendChatLog appends a ChatLogEntry to the chat log file. If maxEntries > 0
+// and the resulting file exceeds that count, the oldest entries are trimmed.
+func AppendChatLog(path string, entry ChatLogEntry, maxEntries int) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	if err := AppendJSONL(path, entry); err != nil {
+		return err
+	}
+	if maxEntries <= 0 {
+		return nil
+	}
+	lines, err := ReadJSONL[ChatLogEntry](path)
+	if err != nil || len(lines) <= maxEntries {
+		return nil
+	}
+	trimmed := lines[len(lines)-maxEntries:]
+	return RewriteJSONL(path, trimmed)
+}
+
+// ReadChatLog reads all entries from a chat log file.
+// Returns nil if the file does not exist.
+func ReadChatLog(path string) ([]ChatLogEntry, error) {
+	entries, err := ReadJSONL[ChatLogEntry](path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return entries, nil
+}

--- a/web/src/config-schema.json
+++ b/web/src/config-schema.json
@@ -125,6 +125,10 @@
 								"replyToReplies": { "type": "boolean" },
 								"reactToEmoji": { "type": "boolean" },
 								"sendReadReceipts": { "type": "boolean" },
+								"group_chat_history": {
+									"type": "integer",
+									"description": "Number of recent group chat messages to log and provide as context to the agent. 0 means use the default (50). Set to -1 to disable."
+								},
 								"model": { "type": "string" },
 								"fallbacks": {
 									"type": "array",

--- a/web/src/stores/settings.ts
+++ b/web/src/stores/settings.ts
@@ -40,6 +40,7 @@ export interface AgentChannel {
 	replyToReplies?: boolean;
 	reactToEmoji?: boolean;
 	sendReadReceipts?: boolean;
+	group_chat_history?: number;
 	model?: string;
 	fallbacks?: string[];
 }

--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -752,6 +752,12 @@
 										Send read receipts
 									</label>
 								</div>
+								<div class="flex items-center gap-2 pt-1">
+									<label class="text-xs text-gray-600 dark:text-gray-400">Group chat history:</label>
+									<input type="number" v-model.number="ch.group_chat_history" min="-1" step="1" placeholder="50"
+										class="w-20 rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-800 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200" />
+									<span class="text-xs text-gray-500 dark:text-gray-500">messages (0 = default 50, -1 = disabled)</span>
+								</div>
 							</div>
 						</div>
 
@@ -2952,6 +2958,10 @@ function normalizedDraftConfig(): AppConfig {
 			replyToReplies: ch.replyToReplies === false ? false : undefined,
 			reactToEmoji: ch.reactToEmoji === false ? false : undefined,
 			sendReadReceipts: ch.sendReadReceipts === false ? false : undefined,
+			group_chat_history:
+				ch.group_chat_history && ch.group_chat_history !== 0
+					? ch.group_chat_history
+					: undefined,
 			allowFrom: (ch.allowFrom ?? [])
 				.map((entry) => ({
 					...entry,


### PR DESCRIPTION
## Summary

- Adds a `GroupChatLogger` interface to Slack, Discord, and Signal channels that fires a callback for **every** group message before `allowFrom` filtering, so non-triggering messages are still captured in the transcript
- New `store/chatlog.go` with `AppendChatLog`/`ReadChatLog` that maintains a per-agent ring-buffer log keyed by `(agentID, channelType, channelID)`
- Agent runner prefers the chat log over the session JSONL for channel conversation history, merging consecutive same-role messages to satisfy LLM alternation rules
- New `ChannelConfig.GroupChatHistory` field: `0` = default 50 messages, `-1` = disabled
- Web UI adds a group chat history input to per-channel settings

## Test plan

- [ ] Configure a Slack/Signal channel with group mentions enabled; confirm non-triggering group messages appear in the agent's conversation context
- [ ] Set `group_chat_history: -1` on a channel and confirm no chat log is written
- [ ] Set `group_chat_history: 10` and confirm the log is capped at 10 entries
- [ ] Verify DM channels are unaffected (only group messages are logged)
- [ ] Run `pnpm test` to confirm all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)