### PR TITLE
Use forgo hot reload for the Go dev server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,9 @@ pnpm dev
 This starts:
 
 - The Vite dev server at **http://localhost:5173** (hot-reload, no HTTPS)
-- The Aviary Go backend at **https://localhost:16677** (auto-restarts on Go file changes via `wgo`)
+- The Aviary Go backend at **https://localhost:16677** (hot-reloads Go file changes via [`forgo run --watch`](https://github.com/lsegal/forgo))
+
+The first `pnpm dev` installs the [forgo](https://github.com/lsegal/forgo) toolchain into `~/.forgo` if it is not already on `PATH`. Set `FORGO_INSTALL_DIR` to install elsewhere or `FORGO_BIN` to point at an existing binary. Platforms without a forgo release fall back to plain `go run` (no reload on change).
 
 Open http://localhost:5173 in your browser. The Vite dev server proxies MCP and API requests to the Go backend.
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,6 +5,7 @@ FROM node:25-bookworm
 ARG TARGETARCH
 
 ENV GOROOT=/usr/local/go
+ENV FORGO_INSTALL_DIR=/usr/local/forgo
 ENV GOPATH=/home/dev/go
 ENV PNPM_HOME=/pnpm
 ENV AVIARY_SANDBOX=true
@@ -65,6 +66,17 @@ RUN case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
       ;; \
   esac \
   && rm -rf /var/lib/apt/lists/*
+
+# forgo powers `pnpm dev`'s Go hot reload; it only ships linux/amd64 binaries,
+# so other architectures fall back to plain `go run` at dev time.
+RUN case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+    amd64) \
+      curl -fsSL https://github.com/lsegal/forgo/releases/latest/download/install.sh | sh \
+      ;; \
+    *) \
+      echo "skipping forgo install: no release for ${TARGETARCH:-$(dpkg --print-architecture)}" \
+      ;; \
+  esac
 
 RUN useradd -m -s /bin/bash dev \
   && echo "dev ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/dev \

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
-	github.com/bokwoon95/wgo v0.6.3 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect
 	github.com/bombsimon/wsl/v5 v5.6.0 // indirect
 	github.com/breml/bidichk v0.3.3 // indirect
@@ -263,7 +262,4 @@ require (
 	mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 // indirect
 )
 
-tool (
-	github.com/bokwoon95/wgo
-	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
-)
+tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,6 @@ github.com/bkielbasa/cyclop v1.2.3 h1:faIVMIGDIANuGPWH031CZJTi2ymOQBULs9H21HSMa5
 github.com/bkielbasa/cyclop v1.2.3/go.mod h1:kHTwA9Q0uZqOADdupvcFJQtp/ksSnytRMe8ztxG8Fuo=
 github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ089M=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
-github.com/bokwoon95/wgo v0.6.3 h1:o6tW56Rr43tjI6HheNJTT4h9CR1DbaHfBeBpXCkLrVI=
-github.com/bokwoon95/wgo v0.6.3/go.mod h1:RqE+rax4lay5crQuLfRGFuh6wLOqm/rysZF11FT58q8=
 github.com/bombsimon/wsl/v4 v4.7.0 h1:1Ilm9JBPRczjyUs6hvOPKvd7VL1Q++PL8M0SXBDf+jQ=
 github.com/bombsimon/wsl/v4 v4.7.0/go.mod h1:uV/+6BkffuzSAVYD+yGyld1AChO7/EuLrCF/8xTiapg=
 github.com/bombsimon/wsl/v5 v5.6.0 h1:4z+/sBqC5vUmSp1O0mS+czxwH9+LKXtCWtHH9rZGQL8=

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 	"scripts": {
 		"claude": "claude --dangerously-skip-permissions",
 		"codex": "codex --dangerously-bypass-approvals-and-sandbox",
-		"dev": "concurrently -n web,doc,srv -c cyan,yellow,green \"vite --host 0.0.0.0\" \"pnpm docs:dev\" \"go tool wgo run ./cmd/aviary serve\"",
+		"dev": "concurrently -n web,doc,srv -c cyan,yellow,green \"vite --host 0.0.0.0\" \"pnpm docs:dev\" \"pnpm dev:go\"",
+		"dev:go": "node scripts/dev-go.mjs serve",
 		"docs:dev": "pnpm --dir docs dev",
 		"docs:build": "pnpm --dir docs build",
 		"docs:preview": "pnpm --dir docs preview",

--- a/scripts/dev-go.mjs
+++ b/scripts/dev-go.mjs
@@ -1,0 +1,105 @@
+// Runs the Aviary Go backend for development under forgo's hot reload
+// (`forgo run --watch`), installing the forgo toolchain first if it is missing.
+import { execFileSync, spawn } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const isWindows = process.platform === "win32";
+const exeExt = isWindows ? ".exe" : "";
+const installDir =
+	process.env.FORGO_INSTALL_DIR ?? path.join(homedir(), ".forgo");
+
+// forgo only publishes release binaries for these platforms.
+const SUPPORTED = new Set(["darwin-arm64", "linux-x64", "win32-x64"]);
+
+function isExecutable(file) {
+	try {
+		accessSync(file, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function findOnPath() {
+	try {
+		const finder = isWindows ? "where" : "which";
+		const found = execFileSync(finder, ["forgo"], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		})
+			.split(/\r?\n/)[0]
+			.trim();
+		return found || null;
+	} catch {
+		return null;
+	}
+}
+
+function findForgo() {
+	if (process.env.FORGO_BIN) return process.env.FORGO_BIN;
+	const installed = path.join(installDir, "bin", `forgo${exeExt}`);
+	if (isExecutable(installed)) return installed;
+	return findOnPath();
+}
+
+function installForgo() {
+	const url = isWindows
+		? "https://github.com/lsegal/forgo/releases/latest/download/install.ps1"
+		: "https://github.com/lsegal/forgo/releases/latest/download/install.sh";
+	console.log(`forgo not found, installing from ${url}`);
+	const [cmd, args] = isWindows
+		? ["powershell", ["-NoProfile", "-Command", `irm ${url} | iex`]]
+		: ["sh", ["-c", `curl -fsSL ${url} | sh`]];
+	execFileSync(cmd, args, { cwd: rootDir, stdio: "inherit" });
+}
+
+function resolveRunner() {
+	const platformKey = `${process.platform}-${process.arch}`;
+	if (!SUPPORTED.has(platformKey)) {
+		console.warn(
+			`warning: forgo publishes no release for ${platformKey}; ` +
+				"falling back to 'go run' without hot reload.",
+		);
+		return { bin: "go", args: ["run"] };
+	}
+
+	let forgo = findForgo();
+	if (!forgo) {
+		installForgo();
+		forgo = findForgo();
+	}
+	if (!forgo) {
+		console.error(
+			"error: forgo installation finished but no forgo binary was found. " +
+				`Install it manually (see https://github.com/lsegal/forgo) or set FORGO_BIN.`,
+		);
+		process.exit(1);
+	}
+	return { bin: forgo, args: ["run", "--watch"] };
+}
+
+const { bin, args } = resolveRunner();
+const child = spawn(bin, [...args, "./cmd/aviary", ...process.argv.slice(2)], {
+	cwd: rootDir,
+	stdio: "inherit",
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+	process.on(signal, () => child.kill(signal));
+}
+
+child.on("exit", (code, signal) => {
+	if (signal) {
+		process.kill(process.pid, signal);
+		return;
+	}
+	process.exit(code ?? 0);
+});
+child.on("error", (err) => {
+	console.error(`error: failed to start ${bin}: ${err.message}`);
+	process.exit(1);
+});


### PR DESCRIPTION
## Root cause

`pnpm dev` ran the Go backend under `go tool wgo run ./cmd/aviary serve`, which kills and restarts the whole process on every Go file change — losing in-memory state, open connections, and the agent/scheduler warm-up on each edit.

## Change

- `pnpm dev` now starts the backend through a new `pnpm dev:go` → `scripts/dev-go.mjs`, which runs `forgo run --watch ./cmd/aviary serve` for true hot reload (changed functions are patched into the running process; state and connections survive).
- The script resolves forgo from `FORGO_BIN`, `$FORGO_INSTALL_DIR`/`~/.forgo/bin`, or `PATH`, and installs the toolchain via forgo's official `install.sh`/`install.ps1` on first run if it is missing. It forwards signals and the child's exit status.
- forgo publishes releases for darwin/arm64, linux/amd64 and windows/amd64 only; on any other platform the script warns and falls back to plain `go run` so `pnpm dev` still works (e.g. linux/arm64 dev containers).
- `Dockerfile.dev` installs forgo into `/usr/local/forgo` for amd64 images and skips it elsewhere.
- Dropped the now-unused `github.com/bokwoon95/wgo` tool dependency from `go.mod` and tidied `go.sum`.
- `CONTRIBUTING.md` documents hot reload, the auto-install, and the `FORGO_BIN` / `FORGO_INSTALL_DIR` overrides.

## User impact

Developer-facing only; no runtime or user-visible behavior changes, so no changelog entry (the repo has no CHANGELOG file).

## Tests

No automated test framework covers the `scripts/*.mjs` dev helpers, so this was verified manually plus the standard suites:

- `node scripts/dev-go.mjs serve --config … --data-dir …` — server started under `forgo run --watch`; editing a live handler produced `forgo: reloaded 6 functions in 3.063s` and the new response header appeared on the **same** process (no restart), confirming hot reload works against this codebase.
- `go test ./...` — pass.
- `go tool golangci-lint run ./...` — 0 issues.
- `pnpm lint:web` (biome + vue-tsc) — pass.

## Note for maintainers

The repository `PR` ruleset (applies to all branches except `main`) requires 8 status checks whose contexts (`Go tests (ubuntu-latest)`, `Go lint`, …) no longer match any job this repo produces (`Test: Go (ubuntu-latest)`, `Lint: Go`, …). Because only branch *creation* is exempt, every follow-up push to a feature branch is rejected with "8 of 8 required status checks are expected". This PR therefore had to be published as a fresh branch; #244 (and previously #243) were blocked by that rule.

Closes #242

**Agents:** claude-code (claude-opus-5[1m])